### PR TITLE
Add onboarding language selection

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,12 +9,14 @@
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/Theme.Material3.DayNight.NoActionBar">
-        <activity android:name=".activities.MainActivity"
+        <activity android:name=".activities.OnBoardLanguageActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity android:name=".activities.MainActivity"
+            android:exported="true" />
     </application>
 </manifest>

--- a/app/src/main/java/com/example/knowlio/activities/MainActivity.java
+++ b/app/src/main/java/com/example/knowlio/activities/MainActivity.java
@@ -2,6 +2,8 @@ package com.example.knowlio.activities;
 
 import android.os.Bundle;
 import android.widget.TextView;
+import android.content.SharedPreferences;
+import androidx.preference.PreferenceManager;
 
 import androidx.appcompat.app.AppCompatActivity;
 
@@ -54,8 +56,10 @@ public class MainActivity extends AppCompatActivity {
                     // כותרת עם תאריך היום
                     tvTitle.setText(getString(R.string.daily_fact_title) + " – " + fact.date);
 
-                    // בחירת שפה: עברית או אנגלית לפי שפת המכשיר
-                    boolean isHeb = Locale.getDefault().getLanguage().equals("he");
+                    // בחירת שפה: עברית או אנגלית לפי העדפת המשתמש
+                    SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(MainActivity.this);
+                    String lang = prefs.getString("pref_lang", Locale.getDefault().getLanguage());
+                    boolean isHeb = lang.equals("he");
                     tvContent.setText(isHeb ? fact.he : fact.en);
                 } else {
                     tvContent.setText("⚠️ ‎Error: empty body");

--- a/app/src/main/java/com/example/knowlio/activities/OnBoardLanguageActivity.java
+++ b/app/src/main/java/com/example/knowlio/activities/OnBoardLanguageActivity.java
@@ -1,0 +1,40 @@
+package com.example.knowlio.activities;
+
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.os.Bundle;
+import android.widget.Button;
+
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.preference.PreferenceManager;
+
+import com.example.knowlio.R;
+
+public class OnBoardLanguageActivity extends AppCompatActivity {
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
+        if (prefs.contains("pref_lang")) {
+            startActivity(new Intent(this, MainActivity.class));
+            finish();
+            return;
+        }
+
+        setContentView(R.layout.activity_on_board_language);
+
+        Button btnEnglish = findViewById(R.id.btnEnglish);
+        Button btnHebrew = findViewById(R.id.btnHebrew);
+
+        btnEnglish.setOnClickListener(v -> saveLangAndStart("en"));
+        btnHebrew.setOnClickListener(v -> saveLangAndStart("he"));
+    }
+
+    private void saveLangAndStart(String lang) {
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
+        prefs.edit().putString("pref_lang", lang).apply();
+        startActivity(new Intent(this, MainActivity.class));
+        finish();
+    }
+}

--- a/app/src/main/res/layout/activity_on_board_language.xml
+++ b/app/src/main/res/layout/activity_on_board_language.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:gravity="center"
+    android:padding="24dp">
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/btnEnglish"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="English"
+        style="@style/Widget.Material3.Button"
+        android:layout_marginBottom="16dp"/>
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/btnHebrew"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="עברית"
+        style="@style/Widget.Material3.Button"/>
+
+</LinearLayout>


### PR DESCRIPTION
## Summary
- add onboarding screen for language selection
- update main activity to read preferred language
- switch launcher to new onboarding activity

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685120020ad48329b100ae308ffa229f