### PR TITLE
Add DailyFetchWorker with WorkManager

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -31,4 +31,5 @@ dependencies {
     implementation 'com.squareup.retrofit2:retrofit:2.11.0'
     implementation 'com.squareup.retrofit2:converter-gson:2.11.0'
     implementation 'com.google.code.gson:gson:2.10.1'
+    implementation 'androidx.work:work-runtime:2.9.0'
 }

--- a/app/src/main/java/com/example/knowlio/activities/MainActivity.java
+++ b/app/src/main/java/com/example/knowlio/activities/MainActivity.java
@@ -4,6 +4,12 @@ import android.os.Bundle;
 import android.widget.TextView;
 import android.content.SharedPreferences;
 import androidx.preference.PreferenceManager;
+import androidx.work.ExistingPeriodicWorkPolicy;
+import androidx.work.PeriodicWorkRequest;
+import androidx.work.WorkManager;
+import java.util.concurrent.TimeUnit;
+
+import com.example.knowlio.work.DailyFetchWorker;
 
 import androidx.appcompat.app.AppCompatActivity;
 
@@ -26,6 +32,13 @@ public class MainActivity extends AppCompatActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        PeriodicWorkRequest request =
+                new PeriodicWorkRequest.Builder(DailyFetchWorker.class, 24, java.util.concurrent.TimeUnit.HOURS)
+                        .build();
+        WorkManager.getInstance(this).enqueueUniquePeriodicWork(
+                "daily_fetch",
+                ExistingPeriodicWorkPolicy.KEEP,
+                request);
         setContentView(R.layout.activity_main);
 
         // 1) מצביעים ל-TextView-ים מה-layout

--- a/app/src/main/java/com/example/knowlio/work/DailyFetchWorker.java
+++ b/app/src/main/java/com/example/knowlio/work/DailyFetchWorker.java
@@ -1,0 +1,90 @@
+package com.example.knowlio.work;
+
+import android.app.PendingIntent;
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+
+import androidx.annotation.NonNull;
+import androidx.core.app.NotificationCompat;
+import androidx.core.app.NotificationManagerCompat;
+import androidx.preference.PreferenceManager;
+import androidx.work.Worker;
+import androidx.work.WorkerParameters;
+
+import com.example.knowlio.R;
+import com.example.knowlio.activities.MainActivity;
+import com.example.knowlio.data.models.DailyFact;
+import com.example.knowlio.data.network.FactsApi;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import java.io.IOException;
+import java.util.Locale;
+
+import retrofit2.Response;
+import retrofit2.Retrofit;
+import retrofit2.converter.gson.GsonConverterFactory;
+
+public class DailyFetchWorker extends Worker {
+
+    public DailyFetchWorker(@NonNull Context context, @NonNull WorkerParameters params) {
+        super(context, params);
+    }
+
+    @NonNull
+    @Override
+    public Result doWork() {
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
+
+        Gson gson = new GsonBuilder()
+                .setLenient()
+                .create();
+        Retrofit retrofit = new Retrofit.Builder()
+                .baseUrl("https://gist.githubusercontent.com/itaital/734a548a728191c298d71e60afcd0dd2/")
+                .addConverterFactory(GsonConverterFactory.create(gson))
+                .build();
+        FactsApi api = retrofit.create(FactsApi.class);
+
+        try {
+            Response<DailyFact> res = api.getFact().execute();
+            if (res.isSuccessful() && res.body() != null) {
+                DailyFact fact = res.body();
+                prefs.edit()
+                        .putString("cached_fact_date", fact.date)
+                        .putString("cached_fact_en", fact.en)
+                        .putString("cached_fact_he", fact.he)
+                        .apply();
+                showNotification(fact, prefs);
+                return Result.success();
+            } else {
+                return Result.retry();
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+            return Result.retry();
+        }
+    }
+
+    private void showNotification(DailyFact fact, SharedPreferences prefs) {
+        NotificationHelper.createDailyFactChannel(getApplicationContext());
+        String lang = prefs.getString("pref_lang", Locale.getDefault().getLanguage());
+        boolean isHeb = "he".equals(lang);
+        String text = isHeb ? fact.he : fact.en;
+
+        Intent intent = new Intent(getApplicationContext(), MainActivity.class);
+        intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
+        PendingIntent pendingIntent = PendingIntent.getActivity(
+                getApplicationContext(), 0, intent, PendingIntent.FLAG_IMMUTABLE);
+
+        NotificationCompat.Builder builder = new NotificationCompat.Builder(getApplicationContext(), NotificationHelper.CHANNEL_ID)
+                .setSmallIcon(android.R.drawable.ic_dialog_info)
+                .setContentTitle("Knowlio • Daily Knowledge")
+                .setContentText(text)
+                .setStyle(new NotificationCompat.BigTextStyle().bigText(text))
+                .setContentIntent(pendingIntent)
+                .setAutoCancel(true);
+
+        NotificationManagerCompat.from(getApplicationContext()).notify(1001, builder.build());
+    }
+}

--- a/app/src/main/java/com/example/knowlio/work/NotificationHelper.java
+++ b/app/src/main/java/com/example/knowlio/work/NotificationHelper.java
@@ -1,0 +1,23 @@
+package com.example.knowlio.work;
+
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.content.Context;
+import android.os.Build;
+
+public class NotificationHelper {
+    public static final String CHANNEL_ID = "daily_fact_channel";
+
+    public static void createDailyFactChannel(Context context) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            NotificationManager nm = context.getSystemService(NotificationManager.class);
+            if (nm != null && nm.getNotificationChannel(CHANNEL_ID) == null) {
+                NotificationChannel channel = new NotificationChannel(
+                        CHANNEL_ID,
+                        "Daily Fact",
+                        NotificationManager.IMPORTANCE_DEFAULT);
+                nm.createNotificationChannel(channel);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- schedule a PeriodicWorkRequest in MainActivity
- implement DailyFetchWorker for downloading daily fact and notifying
- add NotificationHelper utility
- include WorkManager dependency

## Testing
- `./gradlew test --dry-run` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851274b90208329ad622d39eca10930