### PR TITLE
Add daily reminder notifications

### DIFF
--- a/app/src/main/java/com/example/knowlio/activities/MainActivity.java
+++ b/app/src/main/java/com/example/knowlio/activities/MainActivity.java
@@ -7,9 +7,12 @@ import androidx.preference.PreferenceManager;
 import androidx.work.ExistingPeriodicWorkPolicy;
 import androidx.work.PeriodicWorkRequest;
 import androidx.work.WorkManager;
+import androidx.work.PeriodicWorkRequestBuilder;
 import java.util.concurrent.TimeUnit;
+import java.time.Duration;
 
 import com.example.knowlio.work.DailyFetchWorker;
+import com.example.knowlio.work.DailyReminderWorker;
 
 import androidx.appcompat.app.AppCompatActivity;
 
@@ -39,6 +42,14 @@ public class MainActivity extends AppCompatActivity {
                 "daily_fetch",
                 ExistingPeriodicWorkPolicy.KEEP,
                 request);
+
+        PeriodicWorkRequest reminderRequest = new PeriodicWorkRequestBuilder<DailyReminderWorker>(24, TimeUnit.HOURS)
+                .setInitialDelay(calculateNext14hDelay())
+                .build();
+        WorkManager.getInstance(this).enqueueUniquePeriodicWork(
+                "daily_reminder",
+                ExistingPeriodicWorkPolicy.KEEP,
+                reminderRequest);
         setContentView(R.layout.activity_main);
 
         // 1) מצביעים ל-TextView-ים מה-layout
@@ -88,5 +99,22 @@ public class MainActivity extends AppCompatActivity {
                 t.printStackTrace();   // גם בלוגקט
             }
         });
+    }
+
+    private Duration calculateNext14hDelay() {
+        java.util.Calendar cal = java.util.Calendar.getInstance();
+        long now = cal.getTimeInMillis();
+
+        cal.set(java.util.Calendar.HOUR_OF_DAY, 14);
+        cal.set(java.util.Calendar.MINUTE, 0);
+        cal.set(java.util.Calendar.SECOND, 0);
+        cal.set(java.util.Calendar.MILLISECOND, 0);
+
+        if (now >= cal.getTimeInMillis()) {
+            cal.add(java.util.Calendar.DAY_OF_YEAR, 1);
+        }
+
+        long diff = cal.getTimeInMillis() - now;
+        return Duration.ofMillis(diff);
     }
 }

--- a/app/src/main/java/com/example/knowlio/work/DailyReminderWorker.java
+++ b/app/src/main/java/com/example/knowlio/work/DailyReminderWorker.java
@@ -1,0 +1,44 @@
+package com.example.knowlio.work;
+
+import android.app.PendingIntent;
+import android.content.Context;
+import android.content.Intent;
+
+import androidx.annotation.NonNull;
+import androidx.core.app.NotificationCompat;
+import androidx.core.app.NotificationManagerCompat;
+import androidx.work.Worker;
+import androidx.work.WorkerParameters;
+
+import com.example.knowlio.R;
+import com.example.knowlio.activities.MainActivity;
+
+public class DailyReminderWorker extends Worker {
+
+    public DailyReminderWorker(@NonNull Context context, @NonNull WorkerParameters params) {
+        super(context, params);
+    }
+
+    @NonNull
+    @Override
+    public Result doWork() {
+        NotificationHelper.createDailyReminderChannel(getApplicationContext());
+
+        Intent intent = new Intent(getApplicationContext(), MainActivity.class);
+        intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
+        PendingIntent pendingIntent = PendingIntent.getActivity(
+                getApplicationContext(), 0, intent, PendingIntent.FLAG_IMMUTABLE);
+
+        NotificationCompat.Builder builder = new NotificationCompat.Builder(
+                getApplicationContext(), NotificationHelper.REMINDER_CHANNEL_ID)
+                .setSmallIcon(R.drawable.ic_launcher)
+                .setContentTitle("Knowlio")
+                .setContentText("\u2728 Your daily knowledge is ready! Tap to read.")
+                .setContentIntent(pendingIntent)
+                .setAutoCancel(true);
+
+        NotificationManagerCompat.from(getApplicationContext()).notify(2000, builder.build());
+
+        return Result.success();
+    }
+}

--- a/app/src/main/java/com/example/knowlio/work/NotificationHelper.java
+++ b/app/src/main/java/com/example/knowlio/work/NotificationHelper.java
@@ -7,6 +7,7 @@ import android.os.Build;
 
 public class NotificationHelper {
     public static final String CHANNEL_ID = "daily_fact_channel";
+    public static final String REMINDER_CHANNEL_ID = "daily_reminder_channel";
 
     public static void createDailyFactChannel(Context context) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
@@ -15,6 +16,19 @@ public class NotificationHelper {
                 NotificationChannel channel = new NotificationChannel(
                         CHANNEL_ID,
                         "Daily Fact",
+                        NotificationManager.IMPORTANCE_DEFAULT);
+                nm.createNotificationChannel(channel);
+            }
+        }
+    }
+
+    public static void createDailyReminderChannel(Context context) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            NotificationManager nm = context.getSystemService(NotificationManager.class);
+            if (nm != null && nm.getNotificationChannel(REMINDER_CHANNEL_ID) == null) {
+                NotificationChannel channel = new NotificationChannel(
+                        REMINDER_CHANNEL_ID,
+                        "Knowlio Reminders",
                         NotificationManager.IMPORTANCE_DEFAULT);
                 nm.createNotificationChannel(channel);
             }

--- a/app/src/main/res/drawable/ic_launcher.xml
+++ b/app/src/main/res/drawable/ic_launcher.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path android:fillColor="#FF0000" android:pathData="M0,0h24v24h-24z"/>
+</vector>


### PR DESCRIPTION
## Summary
- create DailyReminderWorker for notification channel `daily_reminder_channel`
- extend `NotificationHelper` to create reminder channel
- schedule periodic reminder in `MainActivity`
- compute delay until next 14:00
- add placeholder `ic_launcher` drawable

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68512eac19348329b55d0d4444216164