### PR TITLE
Add offline history support

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -33,5 +33,7 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.10.1'
     implementation 'androidx.work:work-runtime:2.9.0'
     implementation 'androidx.preference:preference:1.2.1'
-    implementation 'androidx.work:work-runtime:2.9.0'
+    // Room database for offline history
+    implementation "androidx.room:room-runtime:2.6.1"
+    annotationProcessor "androidx.room:room-compiler:2.6.1"
 }

--- a/app/src/main/java/com/example/knowlio/activities/MainActivity.java
+++ b/app/src/main/java/com/example/knowlio/activities/MainActivity.java
@@ -5,6 +5,10 @@ import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
 import android.widget.TextView;
+import android.widget.Button;
+
+import androidx.fragment.app.FragmentTransaction;
+import com.example.knowlio.fragments.HistoryFragment;
 
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.app.ActivityCompat;
@@ -77,6 +81,14 @@ public class MainActivity extends AppCompatActivity {
         /* ---------- 3.  הצגת fact במסך ---------- */
         TextView tvContent = findViewById(R.id.tvDailyContent);
         TextView tvTitle   = findViewById(R.id.tvDateTitle);
+        Button btnHistory  = findViewById(R.id.btnHistory);
+
+        btnHistory.setOnClickListener(v -> {
+            FragmentTransaction ft = getSupportFragmentManager().beginTransaction();
+            ft.replace(R.id.container, new HistoryFragment());
+            ft.addToBackStack(null);
+            ft.commit();
+        });
 
         Gson gson = new GsonBuilder().setLenient().create();
 

--- a/app/src/main/java/com/example/knowlio/data/FactsRepository.java
+++ b/app/src/main/java/com/example/knowlio/data/FactsRepository.java
@@ -1,0 +1,31 @@
+package com.example.knowlio.data;
+
+import android.content.Context;
+
+import com.example.knowlio.data.db.DailyFactDao;
+import com.example.knowlio.data.db.DailyFactEntity;
+import com.example.knowlio.data.db.KnowlioDb;
+import com.example.knowlio.data.models.DailyFact;
+
+import java.util.List;
+
+public class FactsRepository {
+    private final DailyFactDao dao;
+
+    public FactsRepository(Context context) {
+        KnowlioDb db = KnowlioDb.getInstance(context);
+        this.dao = db.dailyFactDao();
+    }
+
+    public void saveFact(DailyFact fact) {
+        DailyFactEntity entity = new DailyFactEntity();
+        entity.date = fact.date;
+        entity.en = fact.en;
+        entity.he = fact.he;
+        dao.insert(entity);
+    }
+
+    public List<DailyFactEntity> getHistory() {
+        return dao.getAll();
+    }
+}

--- a/app/src/main/java/com/example/knowlio/data/db/DailyFactDao.java
+++ b/app/src/main/java/com/example/knowlio/data/db/DailyFactDao.java
@@ -1,0 +1,17 @@
+package com.example.knowlio.data.db;
+
+import androidx.room.Dao;
+import androidx.room.Insert;
+import androidx.room.OnConflictStrategy;
+import androidx.room.Query;
+
+import java.util.List;
+
+@Dao
+public interface DailyFactDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    void insert(DailyFactEntity... facts);
+
+    @Query("SELECT * FROM DailyFactEntity ORDER BY date DESC")
+    List<DailyFactEntity> getAll();
+}

--- a/app/src/main/java/com/example/knowlio/data/db/DailyFactEntity.java
+++ b/app/src/main/java/com/example/knowlio/data/db/DailyFactEntity.java
@@ -1,0 +1,13 @@
+package com.example.knowlio.data.db;
+
+import androidx.room.Entity;
+import androidx.room.PrimaryKey;
+
+@Entity
+public class DailyFactEntity {
+    @PrimaryKey(autoGenerate = true)
+    public int id;
+    public String date;
+    public String en;
+    public String he;
+}

--- a/app/src/main/java/com/example/knowlio/data/db/KnowlioDb.java
+++ b/app/src/main/java/com/example/knowlio/data/db/KnowlioDb.java
@@ -1,0 +1,26 @@
+package com.example.knowlio.data.db;
+
+import android.content.Context;
+
+import androidx.room.Database;
+import androidx.room.Room;
+import androidx.room.RoomDatabase;
+
+@Database(entities = {DailyFactEntity.class}, version = 1)
+public abstract class KnowlioDb extends RoomDatabase {
+    private static volatile KnowlioDb INSTANCE;
+
+    public abstract DailyFactDao dailyFactDao();
+
+    public static KnowlioDb getInstance(Context context) {
+        if (INSTANCE == null) {
+            synchronized (KnowlioDb.class) {
+                if (INSTANCE == null) {
+                    INSTANCE = Room.databaseBuilder(context.getApplicationContext(),
+                            KnowlioDb.class, "knowlio.db").build();
+                }
+            }
+        }
+        return INSTANCE;
+    }
+}

--- a/app/src/main/java/com/example/knowlio/fragments/HistoryAdapter.java
+++ b/app/src/main/java/com/example/knowlio/fragments/HistoryAdapter.java
@@ -1,0 +1,58 @@
+package com.example.knowlio.fragments;
+
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.example.knowlio.R;
+import com.example.knowlio.data.db.DailyFactEntity;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class HistoryAdapter extends RecyclerView.Adapter<HistoryAdapter.Holder> {
+    private final List<DailyFactEntity> data = new ArrayList<>();
+    private String lang = "en";
+
+    public void setData(List<DailyFactEntity> items, String lang) {
+        data.clear();
+        if (items != null) {
+            data.addAll(items);
+        }
+        this.lang = lang == null ? "en" : lang;
+        notifyDataSetChanged();
+    }
+
+    @NonNull
+    @Override
+    public Holder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        View v = LayoutInflater.from(parent.getContext()).inflate(android.R.layout.simple_list_item_2, parent, false);
+        return new Holder(v);
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull Holder holder, int position) {
+        DailyFactEntity item = data.get(position);
+        holder.tv1.setText(item.date);
+        holder.tv2.setText("he".equals(lang) ? item.he : item.en);
+    }
+
+    @Override
+    public int getItemCount() {
+        return data.size();
+    }
+
+    static class Holder extends RecyclerView.ViewHolder {
+        TextView tv1;
+        TextView tv2;
+        Holder(View itemView) {
+            super(itemView);
+            tv1 = itemView.findViewById(android.R.id.text1);
+            tv2 = itemView.findViewById(android.R.id.text2);
+        }
+    }
+}

--- a/app/src/main/java/com/example/knowlio/fragments/HistoryFragment.java
+++ b/app/src/main/java/com/example/knowlio/fragments/HistoryFragment.java
@@ -1,0 +1,45 @@
+package com.example.knowlio.fragments;
+
+import android.content.SharedPreferences;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+import androidx.preference.PreferenceManager;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.example.knowlio.R;
+import com.example.knowlio.data.FactsRepository;
+import com.example.knowlio.data.db.DailyFactEntity;
+
+import java.util.List;
+
+public class HistoryFragment extends Fragment {
+
+    private HistoryAdapter adapter;
+
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+        View view = inflater.inflate(R.layout.fragment_history, container, false);
+        RecyclerView rv = view.findViewById(R.id.rvHistory);
+        rv.setLayoutManager(new LinearLayoutManager(requireContext()));
+        adapter = new HistoryAdapter();
+        rv.setAdapter(adapter);
+        loadData();
+        return view;
+    }
+
+    private void loadData() {
+        FactsRepository repo = new FactsRepository(requireContext());
+        List<DailyFactEntity> history = repo.getHistory();
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(requireContext());
+        String lang = prefs.getString("pref_lang", "en");
+        adapter.setData(history, lang);
+    }
+}

--- a/app/src/main/java/com/example/knowlio/work/DailyFetchWorker.java
+++ b/app/src/main/java/com/example/knowlio/work/DailyFetchWorker.java
@@ -15,6 +15,7 @@ import androidx.work.WorkerParameters;
 import com.example.knowlio.R;
 import com.example.knowlio.activities.MainActivity;
 import com.example.knowlio.data.models.DailyFact;
+import com.example.knowlio.data.FactsRepository;
 import com.example.knowlio.data.network.FactsApi;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -45,11 +46,13 @@ public class DailyFetchWorker extends Worker {
                 .addConverterFactory(GsonConverterFactory.create(gson))
                 .build();
         FactsApi api = retrofit.create(FactsApi.class);
+        FactsRepository repo = new FactsRepository(getApplicationContext());
 
         try {
             Response<DailyFact> res = api.getFact().execute();
             if (res.isSuccessful() && res.body() != null) {
                 DailyFact fact = res.body();
+                repo.saveFact(fact);
                 prefs.edit()
                         .putString("cached_fact_date", fact.date)
                         .putString("cached_fact_en", fact.en)

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -6,6 +6,7 @@
     android:orientation="vertical"
     android:padding="16dp"
     android:gravity="center_horizontal"
+    android:id="@+id/container"
     tools:context=".activities.MainActivity">
 
     <!-- כותרת עם תאריך/נושא -->

--- a/app/src/main/res/layout/fragment_history.xml
+++ b/app/src/main/res/layout/fragment_history.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/rvHistory"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"/>
+</FrameLayout>


### PR DESCRIPTION
## Summary
- add Room dependencies
- create database entity, DAO, and DB classes for DailyFact
- implement repository for saving and fetching fact history
- persist fetched facts in DailyFetchWorker
- add HistoryFragment and adapter with RecyclerView
- open HistoryFragment from MainActivity and mark layout container

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68513c704fa883298e64217504d6d16d