### PR TITLE
Add bundle history views

### DIFF
--- a/app/src/main/java/com/example/knowlio/data/models/LanguageContent.java
+++ b/app/src/main/java/com/example/knowlio/data/models/LanguageContent.java
@@ -4,6 +4,6 @@ import java.util.List;
 
 public class LanguageContent {
     public QuoteSection quoteOfTheDay;
-    public List<KnowledgeItem> interestingKnowledge;
-    public PeopleSection whoWereThey;
+    public List<String> interestingKnowledge;
+    public List<String> whoWereThey;
 }

--- a/app/src/main/java/com/example/knowlio/data/network/FactsApi.java
+++ b/app/src/main/java/com/example/knowlio/data/network/FactsApi.java
@@ -9,4 +9,7 @@ import retrofit2.http.Url;
 public interface FactsApi {
     @GET
     Call<DailyQuoteBundle> getBundle(@Url String url);
+
+    @GET
+    Call<DailyQuoteBundle> getDaily(@Url String rawUrl);
 }

--- a/app/src/main/java/com/example/knowlio/fragments/HistoryFragment.java
+++ b/app/src/main/java/com/example/knowlio/fragments/HistoryFragment.java
@@ -1,56 +1,123 @@
 package com.example.knowlio.fragments;
 
-import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.LinearLayout;
+import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.preference.PreferenceManager;
-import androidx.recyclerview.widget.LinearLayoutManager;
-import androidx.recyclerview.widget.RecyclerView;
 
 import com.example.knowlio.R;
 import com.example.knowlio.data.FactsRepository;
-import com.example.knowlio.data.db.DailyFactEntity;
+import com.example.knowlio.data.models.DailyQuoteBundle;
+import com.example.knowlio.data.models.LanguageContent;
+import com.google.android.material.datepicker.CalendarConstraints;
+import com.google.android.material.datepicker.MaterialDatePicker;
+import com.google.android.material.datepicker.DateValidatorPointBackward;
+import com.google.android.material.snackbar.Snackbar;
+import com.google.android.material.textfield.TextInputEditText;
+import androidx.core.widget.TextViewCompat;
 
-import java.util.List;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Locale;
 
 public class HistoryFragment extends Fragment {
 
-    private HistoryAdapter adapter;
+    private TextInputEditText etDate;
+    private TextView tvQuote;
+    private TextView tvKnowledge;
+    private LinearLayout peopleLayout;
+    private View cardQuote, cardKnowledge, cardPeople;
+    private FactsRepository repo;
     private String lang;
 
-    @Nullable @Override
+    @Nullable
+    @Override
     public View onCreateView(@NonNull LayoutInflater inflater,
                              @Nullable ViewGroup container,
                              @Nullable Bundle savedInstanceState) {
+        View v = inflater.inflate(R.layout.fragment_history, container, false);
 
-        View view = inflater.inflate(R.layout.fragment_history, container, false);
+        etDate = v.findViewById(R.id.etDate);
+        tvQuote = v.findViewById(R.id.tvQuoteHistory);
+        tvKnowledge = v.findViewById(R.id.tvKnowledgeHistory);
+        peopleLayout = v.findViewById(R.id.layoutPeopleHistory);
+        cardQuote = v.findViewById(R.id.cardQuote);
+        cardKnowledge = v.findViewById(R.id.cardKnowledge);
+        cardPeople = v.findViewById(R.id.cardPeople);
 
-        /* RecyclerView */
-        RecyclerView rv = view.findViewById(R.id.rvHistory);
-        rv.setLayoutManager(new LinearLayoutManager(requireContext()));
-        adapter = new HistoryAdapter();
-        rv.setAdapter(adapter);
+        repo = new FactsRepository(requireContext());
+        lang = PreferenceManager.getDefaultSharedPreferences(requireContext())
+                .getString("pref_lang", Locale.getDefault().getLanguage());
 
-        /* שפת המשתמש */
-        SharedPreferences prefs =
-                PreferenceManager.getDefaultSharedPreferences(requireContext());
-        lang = prefs.getString("pref_lang", "en");
+        etDate.setOnClickListener(v1 -> openPicker());
 
-        /* Repository + LiveData */
-        FactsRepository repo = new FactsRepository(requireContext());
-        repo.getHistory().observe(getViewLifecycleOwner(), this::updateUi);
-
-        return view;
+        return v;
     }
 
-    /** מקבלת את הרשימה מה-LiveData ומזרימה אותה לאדפטר */
-    private void updateUi(List<DailyFactEntity> list) {
-        adapter.setData(list, lang);   // HistoryAdapter שלך כבר יודע לסנן לפי lang
+    private void openPicker() {
+        CalendarConstraints constraints = new CalendarConstraints.Builder()
+                .setValidator(DateValidatorPointBackward.now())
+                .build();
+        MaterialDatePicker<Long> picker = MaterialDatePicker.Builder.datePicker()
+                .setCalendarConstraints(constraints)
+                .build();
+        picker.addOnPositiveButtonClickListener(time -> {
+            LocalDate date = Instant.ofEpochMilli(time)
+                    .atZone(ZoneId.systemDefault())
+                    .toLocalDate();
+            etDate.setText(date.toString());
+            showBundle(date);
+        });
+        picker.show(getParentFragmentManager(), "picker");
+    }
+
+    private void showBundle(LocalDate date) {
+        DailyQuoteBundle bundle = repo.getBundle(date);
+        if (bundle == null) {
+            Snackbar.make(etDate, R.string.no_data, Snackbar.LENGTH_LONG).show();
+            cardQuote.setVisibility(View.GONE);
+            cardKnowledge.setVisibility(View.GONE);
+            cardPeople.setVisibility(View.GONE);
+            return;
+        }
+
+        LanguageContent c = bundle.languages.get(lang);
+        if (c == null) c = bundle.languages.get("en");
+
+        if (c != null && c.quoteOfTheDay != null && !c.quoteOfTheDay.isEmpty()) {
+            tvQuote.setText(c.quoteOfTheDay.get(0));
+            cardQuote.setVisibility(View.VISIBLE);
+        } else {
+            cardQuote.setVisibility(View.GONE);
+        }
+
+        if (c != null && c.interestingKnowledge != null && !c.interestingKnowledge.isEmpty()) {
+            tvKnowledge.setText(c.interestingKnowledge.get(0));
+            cardKnowledge.setVisibility(View.VISIBLE);
+        } else {
+            cardKnowledge.setVisibility(View.GONE);
+        }
+
+        peopleLayout.removeAllViews();
+        if (c != null && c.whoWereThey != null && !c.whoWereThey.isEmpty()) {
+            for (String item : c.whoWereThey) {
+                TextView t = new TextView(requireContext());
+                t.setText("• " + item);
+                TextViewCompat.setTextAppearance(t, com.google.android.material.R.style.TextAppearance_Material3_BodyLarge);
+                t.setPadding(0, 0, 0, 12);
+                peopleLayout.addView(t);
+            }
+            cardPeople.setVisibility(View.VISIBLE);
+        } else {
+            cardPeople.setVisibility(View.GONE);
+        }
     }
 }

--- a/app/src/main/java/com/example/knowlio/fragments/HomeFragment.java
+++ b/app/src/main/java/com/example/knowlio/fragments/HomeFragment.java
@@ -1,7 +1,6 @@
 package com.example.knowlio.fragments;
 
 import android.content.SharedPreferences;
-import android.graphics.Typeface;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -19,17 +18,14 @@ import androidx.preference.PreferenceManager;
 
 import com.example.knowlio.R;
 import com.example.knowlio.data.FactsRepository;
-import com.example.knowlio.data.models.KnowledgeItem;
 import com.example.knowlio.data.models.LanguageContent;
 
 import java.util.Locale;
-import java.util.Map;
 
 public class HomeFragment extends Fragment {
 
-    private TextView tvQuote1;
-    private TextView tvQuote2;
-    private LinearLayout knowledgeLayout;
+    private TextView tvQuote;
+    private TextView tvKnowledge;
     private LinearLayout peopleLayout;
     private TextView tvEmpty;
 
@@ -40,9 +36,8 @@ public class HomeFragment extends Fragment {
                              @Nullable Bundle savedInstanceState) {
         View v = inflater.inflate(R.layout.fragment_home, container, false);
 
-        tvQuote1 = v.findViewById(R.id.tvQuote1);
-        tvQuote2 = v.findViewById(R.id.tvQuote2);
-        knowledgeLayout = v.findViewById(R.id.layoutKnowledge);
+        tvQuote = v.findViewById(R.id.tvQuote);
+        tvKnowledge = v.findViewById(R.id.tvKnowledge);
         peopleLayout = v.findViewById(R.id.layoutPeople);
         tvEmpty = v.findViewById(R.id.tvEmpty);
 
@@ -77,38 +72,22 @@ public class HomeFragment extends Fragment {
             tvEmpty.setVisibility(View.GONE);
         }
 
-        if (content.quoteOfTheDay != null) {
-            if (content.quoteOfTheDay.size() > 0) {
-                tvQuote1.setText(content.quoteOfTheDay.get(0));
-            }
-            if (content.quoteOfTheDay.size() > 1) {
-                tvQuote2.setText(content.quoteOfTheDay.get(1));
-            }
+        if (content.quoteOfTheDay != null && !content.quoteOfTheDay.isEmpty()) {
+            tvQuote.setText(content.quoteOfTheDay.get(0));
         }
 
-        knowledgeLayout.removeAllViews();
-        if (content.interestingKnowledge != null) {
-            for (KnowledgeItem item : content.interestingKnowledge) {
-                TextView t1 = new TextView(requireContext());
-                t1.setText(item.title);
-                t1.setTypeface(null, Typeface.BOLD);
-                TextViewCompat.setTextAppearance(t1, com.google.android.material.R.style.TextAppearance_Material3_BodyLarge);
-                knowledgeLayout.addView(t1);
-
-                TextView t2 = new TextView(requireContext());
-                t2.setText(item.text);
-                TextViewCompat.setTextAppearance(t2, com.google.android.material.R.style.TextAppearance_Material3_BodyMedium);
-                t2.setPadding(0, 0, 0, 12);
-                knowledgeLayout.addView(t2);
-            }
+        if (content.interestingKnowledge != null && !content.interestingKnowledge.isEmpty()) {
+            tvKnowledge.setText(content.interestingKnowledge.get(0));
+        } else {
+            tvKnowledge.setText("");
         }
 
         peopleLayout.removeAllViews();
         if (content.whoWereThey != null) {
-            for (Map.Entry<String, String> entry : content.whoWereThey.entrySet()) {
+            for (String item : content.whoWereThey) {
                 TextView t = new TextView(requireContext());
-                t.setText(entry.getKey() + " – " + entry.getValue());
-                TextViewCompat.setTextAppearance(t, com.google.android.material.R.style.TextAppearance_Material3_BodyMedium);
+                t.setText("• " + item);
+                TextViewCompat.setTextAppearance(t, com.google.android.material.R.style.TextAppearance_Material3_BodyLarge);
                 t.setPadding(0, 0, 0, 12);
                 peopleLayout.addView(t);
             }

--- a/app/src/main/java/com/example/knowlio/work/DailyBundleWorker.java
+++ b/app/src/main/java/com/example/knowlio/work/DailyBundleWorker.java
@@ -24,7 +24,8 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
 import java.io.IOException;
-import java.util.Calendar;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 
@@ -63,18 +64,17 @@ public class DailyBundleWorker extends Worker {
         FactsRepository repo = new FactsRepository(getApplicationContext());
 
         /* ---------- URL של היום ---------- */
-        Calendar cal = Calendar.getInstance();
-        String formatted = String.format(Locale.US, "%04d_%02d_%02d",
-                cal.get(Calendar.YEAR), cal.get(Calendar.MONTH) + 1, cal.get(Calendar.DAY_OF_MONTH));
+        LocalDate today = LocalDate.now();
+        String formatted = today.format(DateTimeFormatter.ofPattern("yyyy_MM_dd"));
         String url = BASE + "daily_knowledge_" + formatted + ".json";
 
         try {
-            Response<DailyQuoteBundle> res = api.getBundle(url).execute();
+            Response<DailyQuoteBundle> res = api.getDaily(url).execute();
 
             if (res.isSuccessful() && res.body() != null) {
                 /* ✓ הצלחה – שומרים ומציגים */
                 DailyQuoteBundle bundle = res.body();
-                repo.saveBundle(bundle);
+                repo.saveBundle(today, bundle);
                 showNotification(bundle, prefs);
                 return Result.success();
 

--- a/app/src/main/res/layout/fragment_history.xml
+++ b/app/src/main/res/layout/fragment_history.xml
@@ -1,10 +1,110 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/rvHistory"
+    <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"/>
-</FrameLayout>
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="16dp">
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/select_date">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/etDate"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:focusable="false" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.card.MaterialCardView
+            android:id="@+id/cardQuote"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:visibility="gone"
+            app:shapeAppearanceOverlay="@style/ShapeAppearance.Material3.Corner.ExtraLarge">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:padding="16dp">
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="🏆 Quote of the Day"
+                    style="@style/TextAppearance.Material3.TitleMedium" />
+
+                <TextView
+                    android:id="@+id/tvQuoteHistory"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:textStyle="italic"
+                    style="@style/TextAppearance.Material3.HeadlineSmall" />
+            </LinearLayout>
+        </com.google.android.material.card.MaterialCardView>
+
+        <com.google.android.material.card.MaterialCardView
+            android:id="@+id/cardKnowledge"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:visibility="gone"
+            app:shapeAppearanceOverlay="@style/ShapeAppearance.Material3.Corner.ExtraLarge">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:padding="16dp">
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="🧠 Interesting Knowledge"
+                    style="@style/TextAppearance.Material3.TitleMedium" />
+
+                <TextView
+                    android:id="@+id/tvKnowledgeHistory"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    style="@style/TextAppearance.Material3.BodyLarge" />
+            </LinearLayout>
+        </com.google.android.material.card.MaterialCardView>
+
+        <com.google.android.material.card.MaterialCardView
+            android:id="@+id/cardPeople"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:visibility="gone"
+            app:shapeAppearanceOverlay="@style/ShapeAppearance.Material3.Corner.ExtraLarge">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:padding="16dp">
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="📚 Who Were They"
+                    style="@style/TextAppearance.Material3.TitleMedium" />
+
+                <LinearLayout
+                    android:id="@+id/layoutPeopleHistory"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical" />
+            </LinearLayout>
+        </com.google.android.material.card.MaterialCardView>
+    </LinearLayout>
+</ScrollView>

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -14,57 +14,44 @@
             android:id="@+id/tvEmpty"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="Come back later – today’s content is not available yet"
+            android:text="@string/home_empty"
             android:visibility="gone"
             style="@style/TextAppearance.Material3.BodyLarge" />
 
         <com.google.android.material.card.MaterialCardView
+            android:id="@+id/cardQuote"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
-            app:strokeWidth="0dp"
-            app:cardElevation="4dp">
+            android:layout_marginTop="16dp"
+            app:shapeAppearanceOverlay="@style/ShapeAppearance.Material3.Corner.ExtraLarge">
 
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="vertical"
-                android:gravity="center_horizontal"
                 android:padding="16dp">
 
                 <TextView
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:text="📜 Quote of the Day"
-                    android:textColor="@color/purple500"
+                    android:text="🏆 Quote of the Day"
                     style="@style/TextAppearance.Material3.TitleMedium" />
 
                 <TextView
-                    android:id="@+id/tvQuote1"
-                    android:layout_width="wrap_content"
+                    android:id="@+id/tvQuote"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:gravity="center"
-                    android:textAlignment="center"
-                    style="@style/TextAppearance.Material3.BodyLarge"
-                    android:paddingTop="8dp" />
-
-                <TextView
-                    android:id="@+id/tvQuote2"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:gravity="center"
-                    android:textAlignment="center"
-                    style="@style/TextAppearance.Material3.BodyLarge" />
-
+                    android:textStyle="italic"
+                    style="@style/TextAppearance.Material3.HeadlineSmall" />
             </LinearLayout>
         </com.google.android.material.card.MaterialCardView>
 
         <com.google.android.material.card.MaterialCardView
+            android:id="@+id/cardKnowledge"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
-            app:strokeWidth="0dp"
-            app:cardElevation="4dp">
+            android:layout_marginTop="16dp"
+            app:shapeAppearanceOverlay="@style/ShapeAppearance.Material3.Corner.ExtraLarge">
 
             <LinearLayout
                 android:layout_width="match_parent"
@@ -76,24 +63,22 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:text="🧠 Interesting Knowledge"
-                    android:textColor="@color/purple500"
                     style="@style/TextAppearance.Material3.TitleMedium" />
 
-                <LinearLayout
-                    android:id="@+id/layoutKnowledge"
+                <TextView
+                    android:id="@+id/tvKnowledge"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:orientation="vertical" />
-
+                    style="@style/TextAppearance.Material3.BodyLarge" />
             </LinearLayout>
         </com.google.android.material.card.MaterialCardView>
 
         <com.google.android.material.card.MaterialCardView
+            android:id="@+id/cardPeople"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
-            app:strokeWidth="0dp"
-            app:cardElevation="4dp">
+            android:layout_marginTop="16dp"
+            app:shapeAppearanceOverlay="@style/ShapeAppearance.Material3.Corner.ExtraLarge">
 
             <LinearLayout
                 android:layout_width="match_parent"
@@ -105,7 +90,6 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:text="📚 Who Were They"
-                    android:textColor="@color/purple500"
                     style="@style/TextAppearance.Material3.TitleMedium" />
 
                 <LinearLayout
@@ -113,7 +97,6 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:orientation="vertical" />
-
             </LinearLayout>
         </com.google.android.material.card.MaterialCardView>
 
@@ -121,8 +104,7 @@
             android:id="@+id/btnHistory"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="16dp"
+            android:layout_marginTop="24dp"
             android:text="@string/history_button" />
-
     </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -4,4 +4,7 @@
     <string name="quiz_button">מבחן יומי</string>
     <string name="history_button">היסטוריה</string>
     <string name="sample_fact">כאן תופיע עובדה לדוגמה.</string>
+    <string name="home_empty">חזור מאוחר יותר – תוכן היום עדיין לא זמין</string>
+    <string name="select_date">בחר תאריך</string>
+    <string name="no_data">אין נתונים לתאריך הנבחר</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,4 +5,7 @@
     <string name="quiz_button">Daily Quiz</string>
     <string name="history_button">History</string>
     <string name="sample_fact">Sample fact will appear here.</string>
+    <string name="home_empty">Come back later – today’s content is not available yet</string>
+    <string name="select_date">Select date</string>
+    <string name="no_data">No data for selected date</string>
 </resources>


### PR DESCRIPTION
## Summary
- support storing multiple DailyQuoteBundle objects and listing dates
- fetch bundles via new `FactsApi.getDaily`
- display today's bundle on HomeFragment with new layout
- implement date-based HistoryFragment
- add English/Hebrew strings

## Testing
- `./gradlew assembleDebug`

------
https://chatgpt.com/codex/tasks/task_e_685941f6040c832980c299e0071aaf33