### PR TITLE
Fix Material component version for ExposedDropdownMenu

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,7 +25,7 @@ android {
 
 dependencies {
     implementation 'androidx.appcompat:appcompat:1.7.0'
-    implementation 'com.google.android.material:material:1.12.0'
+    implementation 'com.google.android.material:material:1.12.0-rc01'
     implementation 'androidx.constraintlayout:constraintlayout:2.2.0'
 
     implementation 'com.squareup.retrofit2:retrofit:2.11.0'

--- a/app/src/main/res/layout/fragment_history.xml
+++ b/app/src/main/res/layout/fragment_history.xml
@@ -12,7 +12,7 @@
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/dropdownLayout"
-            style="@style/Widget.Material3.ExposedDropdownMenu"
+            style="?attr/exposedDropdownMenuStyle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:hint="@string/select_date">


### PR DESCRIPTION
## Summary
- use the compat attr for the exposed dropdown menu style
- update Material Components library to 1.12.0-rc01

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a948a2b7083298938522cc0173745