### PR TITLE
Implement live history flow and navigation

### DIFF
--- a/app/src/main/java/com/example/knowlio/activities/MainActivity.java
+++ b/app/src/main/java/com/example/knowlio/activities/MainActivity.java
@@ -101,6 +101,9 @@ public class MainActivity extends AppCompatActivity {
                     .replace(R.id.container, new com.example.knowlio.fragments.HistoryFragment())
                     .addToBackStack(null)
                     .commit();
+            if (getSupportActionBar() != null) {
+                getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+            }
             return true;
         } else if (id == R.id.menu_language) {
             showLanguageDialog();
@@ -160,6 +163,20 @@ public class MainActivity extends AppCompatActivity {
                 .setMessage(msg)
                 .setPositiveButton(android.R.string.ok, null)
                 .show();
+    }
+
+    @Override
+    public boolean onSupportNavigateUp() {
+        onBackPressed();
+        return true;
+    }
+
+    @Override
+    public void onBackPressed() {
+        super.onBackPressed();
+        if (getSupportFragmentManager().getBackStackEntryCount() == 0 && getSupportActionBar() != null) {
+            getSupportActionBar().setDisplayHomeAsUpEnabled(false);
+        }
     }
 
     /** כמה מילישניות נשארו עד 14:00 הקרוב. */

--- a/app/src/main/java/com/example/knowlio/data/db/DailyBundleDao.java
+++ b/app/src/main/java/com/example/knowlio/data/db/DailyBundleDao.java
@@ -16,9 +16,15 @@ public interface DailyBundleDao {
     @Query("SELECT json FROM DailyBundleEntity WHERE date = :date LIMIT 1")
     String getJson(String date);
 
+    @Query("SELECT * FROM DailyBundleEntity WHERE date = :date LIMIT 1")
+    DailyBundleEntity getByDate(String date);
+
     @Query("SELECT json FROM DailyBundleEntity WHERE date = :date LIMIT 1")
     LiveData<String> observeJson(String date);
 
-    @Query("SELECT date FROM DailyBundleEntity ORDER BY date DESC")
-    List<String> listDates();
+    @Query("SELECT DISTINCT date FROM DailyBundleEntity ORDER BY date DESC")
+    LiveData<List<String>> listDates();
+
+    @Query("SELECT DISTINCT date FROM DailyBundleEntity ORDER BY date DESC")
+    List<String> listDatesSync();
 }

--- a/app/src/main/java/com/example/knowlio/fragments/HistoryFragment.java
+++ b/app/src/main/java/com/example/knowlio/fragments/HistoryFragment.java
@@ -55,19 +55,21 @@ public class HistoryFragment extends Fragment {
         lang = PreferenceManager.getDefaultSharedPreferences(requireContext())
                 .getString("pref_lang", Locale.getDefault().getLanguage());
 
-        setupDropdown();
-
         return v;
     }
 
-    private void setupDropdown() {
-        java.util.List<java.time.LocalDate> dates = repo.listDates();
-        String[] ds = new String[dates.size()];
-        for (int i = 0; i < dates.size(); i++) ds[i] = dates.get(i).toString();
-        ArrayAdapter<String> adapter = new ArrayAdapter<>(requireContext(), android.R.layout.simple_list_item_1, ds);
-        etDate.setAdapter(adapter);
-        etDate.setOnItemClickListener((p, v1, pos, id) -> {
-            showBundle(LocalDate.parse(adapter.getItem(pos)));
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+        repo.listDatesLive().observe(getViewLifecycleOwner(), dates -> {
+            if (dates == null) return;
+            String[] ds = new String[dates.size()];
+            for (int i = 0; i < dates.size(); i++) ds[i] = dates.get(i).toString();
+            ArrayAdapter<String> adapter = new ArrayAdapter<>(requireContext(), android.R.layout.simple_list_item_1, ds);
+            etDate.setAdapter(adapter);
+            etDate.setOnItemClickListener((p, v1, pos, id) -> {
+                showBundle(LocalDate.parse(adapter.getItem(pos)));
+            });
         });
     }
 

--- a/app/src/main/java/com/example/knowlio/fragments/HomeFragment.java
+++ b/app/src/main/java/com/example/knowlio/fragments/HomeFragment.java
@@ -18,6 +18,7 @@ import com.example.knowlio.R;
 import com.example.knowlio.data.FactsRepository;
 import com.example.knowlio.data.models.LanguageContent;
 import com.example.knowlio.data.models.KnowledgeItem;
+import com.example.knowlio.data.models.DailyQuoteBundle;
 import android.graphics.Typeface;
 
 import java.util.Locale;
@@ -27,6 +28,7 @@ public class HomeFragment extends Fragment {
     private LinearLayout quotesLayout;
     private LinearLayout knowledgeLayout;
     private LinearLayout peopleLayout;
+    private View cardQuote, cardKnowledge, cardPeople;
     private TextView tvEmpty;
 
     @Nullable
@@ -39,6 +41,9 @@ public class HomeFragment extends Fragment {
         quotesLayout = v.findViewById(R.id.layoutQuotes);
         knowledgeLayout = v.findViewById(R.id.layoutKnowledge);
         peopleLayout = v.findViewById(R.id.layoutPeople);
+        cardQuote = v.findViewById(R.id.cardQuote);
+        cardKnowledge = v.findViewById(R.id.cardKnowledge);
+        cardPeople = v.findViewById(R.id.cardPeople);
         tvEmpty = v.findViewById(R.id.tvEmpty);
 
 
@@ -52,26 +57,27 @@ public class HomeFragment extends Fragment {
         String lang = prefs.getString("pref_lang", Locale.getDefault().getLanguage());
 
         FactsRepository repo = new FactsRepository(requireContext());
-        repo.observeBundle(java.time.LocalDate.now()).observe(getViewLifecycleOwner(), bundle -> {
-            LanguageContent content = null;
-            if (bundle != null && bundle.languages != null) {
-                content = bundle.languages.get(lang);
-                if (content == null) content = bundle.languages.get("en");
-            }
-            showContent(content);
+        java.time.LocalDate today = java.time.LocalDate.now();
+        repo.getBundleLive(today).observe(getViewLifecycleOwner(), bundle -> {
+            showBundle(bundle, lang);
         });
     }
 
-    private void showContent(@Nullable LanguageContent content) {
-        if (content == null) {
+    private void showBundle(@Nullable DailyQuoteBundle bundle, String lang) {
+        if (bundle == null) {
             tvEmpty.setVisibility(View.VISIBLE);
+            cardQuote.setVisibility(View.GONE);
+            cardKnowledge.setVisibility(View.GONE);
+            cardPeople.setVisibility(View.GONE);
             return;
-        } else {
-            tvEmpty.setVisibility(View.GONE);
         }
 
+        tvEmpty.setVisibility(View.GONE);
+        LanguageContent content = bundle.languages.get(lang);
+        if (content == null) content = bundle.languages.get("en");
+
         quotesLayout.removeAllViews();
-        if (content.quoteOfTheDay != null) {
+        if (content != null && content.quoteOfTheDay != null && !content.quoteOfTheDay.isEmpty()) {
             for (String q : content.quoteOfTheDay) {
                 TextView t = new TextView(requireContext());
                 t.setText("\u275D " + q + " \u275E");
@@ -79,10 +85,13 @@ public class HomeFragment extends Fragment {
                 t.setPadding(0, 0, 0, 12);
                 quotesLayout.addView(t);
             }
+            cardQuote.setVisibility(View.VISIBLE);
+        } else {
+            cardQuote.setVisibility(View.GONE);
         }
 
         knowledgeLayout.removeAllViews();
-        if (content.interestingKnowledge != null) {
+        if (content != null && content.interestingKnowledge != null && !content.interestingKnowledge.isEmpty()) {
             for (KnowledgeItem item : content.interestingKnowledge) {
                 TextView title = new TextView(requireContext());
                 title.setText(item.title);
@@ -95,10 +104,13 @@ public class HomeFragment extends Fragment {
                 knowledgeLayout.addView(title);
                 knowledgeLayout.addView(body);
             }
+            cardKnowledge.setVisibility(View.VISIBLE);
+        } else {
+            cardKnowledge.setVisibility(View.GONE);
         }
 
         peopleLayout.removeAllViews();
-        if (content.whoWereThey != null) {
+        if (content != null && content.whoWereThey != null && !content.whoWereThey.isEmpty()) {
             for (String item : content.whoWereThey) {
                 TextView t = new TextView(requireContext());
                 t.setText("• " + item);
@@ -106,6 +118,9 @@ public class HomeFragment extends Fragment {
                 t.setPadding(0, 0, 0, 12);
                 peopleLayout.addView(t);
             }
+            cardPeople.setVisibility(View.VISIBLE);
+        } else {
+            cardPeople.setVisibility(View.GONE);
         }
     }
 }

--- a/app/src/main/java/com/example/knowlio/work/DailyBundleWorker.java
+++ b/app/src/main/java/com/example/knowlio/work/DailyBundleWorker.java
@@ -108,6 +108,7 @@ public class DailyBundleWorker extends Worker {
                 }
 
                 repo.saveBundle(bundle);
+                prefs.edit().putString("last_fetch", today.toString()).apply();
                 showNotification(bundle, prefs);
                 return Result.success();
 


### PR DESCRIPTION
## Summary
- observe bundles and dates via LiveData
- show today's content in HomeFragment
- populate HistoryFragment dropdown dynamically
- store last fetch date in DailyBundleWorker
- enable up navigation from History

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ad86c0b7c8329ad5d706f7bd6cc8a