### PR TITLE
Fix flexible JSON schema

### DIFF
--- a/.github/workflows/generate-gist.yml
+++ b/.github/workflows/generate-gist.yml
@@ -30,7 +30,13 @@ jobs:
 
       # הפעל את הסקריפט שמייצר ומעדכן את הגיסט
       - name: Generate & patch gist
+        id: bundle
         env:
           GIST_ID:  d2a78fdf63a5112ba58e530982d9f823   # ← כאן הדבק את ה-hash של הגיסט שלך
           GH_TOKEN: ${{ secrets.GH_TOKEN_WRITE }}      # נשאר הטוקן היחיד
-        run: python scripts/generate_and_patch_gist.py
+        run: |
+          python scripts/generate_and_patch_gist.py
+          echo "path=daily_knowledge_$(date +%Y_%m_%d).json" >> "$GITHUB_OUTPUT"
+
+      - name: Validate schema
+        run: python scripts/test_schema.py "${{ steps.bundle.outputs.path }}"

--- a/scripts/test_schema.py
+++ b/scripts/test_schema.py
@@ -1,0 +1,9 @@
+import json, pathlib, sys
+
+data = json.load(open(sys.argv[1]))
+en = data["languages"]["en"]
+assert len(en["quoteOfTheDay"]) >= 2
+assert len(en["interestingKnowledge"]) >= 2
+assert all(isinstance(k, dict) and {"title", "text"} <= k.keys()
+           for k in en["interestingKnowledge"])
+


### PR DESCRIPTION
## Summary
- update gist generation to output at least two quotes and knowledge items
- write generated JSON file locally
- add test to validate flexible schema
- run schema test in workflow

## Testing
- `python -m py_compile scripts/generate_and_patch_gist.py scripts/test_schema.py`
- `python scripts/test_schema.py sample.json` *(temporary file)*
- `sh ./gradlew testDebugUnitTest --quiet` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685af5b3da048329841631dd13237428